### PR TITLE
Customizability

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -1,6 +1,6 @@
 $(function() {
   var initialLocation;
-  var center = new google.maps.LatLng(37.774929, -122.419416);
+  var center = new google.maps.LatLng(<%= AdoptAThing::Application.config.x.origin %>);
   var browserSupportFlag =  new Boolean();
   var errorClass = 'has-error';
   var current_user_id = $('#current_user_id').val() ? $('#current_user_id').val() : '';

--- a/config/initializers/customization.rb
+++ b/config/initializers/customization.rb
@@ -1,0 +1,2 @@
+AdoptAThing::Application.config.x.origin = '35.996288, -78.9037087'
+AdoptAThing::Application.config.x.city = "Durham"


### PR DESCRIPTION
I'm intending this pull request to be the beginning of an effort to make this web app truly customizable, so it can be cloned and deployed in a different location without having to change the core code base.  The goal is to make the efforts in the different cities compatible with each other, so that we can all contribute to and benefit from a unified code base.

Configurable values can be defined in `config/initializers/customization.rb` like:
```ruby
AdoptAThing::Application.config.x.variable
```
...and then used in all of the templates as:
```erb
<%= AdoptAThing::Application.config.x.variable %>
```